### PR TITLE
Add .cool extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "languages": [{
             "id": "cool",
             "aliases": ["COOL", "cool"],
-            "extensions": [".cl"],
+            "extensions": [".cl", ".cool"],
             "configuration": "./cool.configuration.json"
         }],
         "grammars": [{


### PR DESCRIPTION
Its very common to use both `.cool` and `.cl` extensions. I am wondering do you mind accepting this change and if so can you please push it to VS marketplace? thank you so much